### PR TITLE
Installing Protobuf requires tar

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -100,7 +100,7 @@ $ENV:BAZEL_SH = "C:\msys64\usr\bin\bash.exe"
 if (!(CheckInstalled pacman)) {
     $version = askForVersion "20180531.0.0"
     choco install msys2 --version $version --params "/NoUpdate /InstallDir:C:\msys64"
-    pacman -S --noconfirm patch unzip
+    pacman -S --noconfirm patch unzip tar
 }
 
 if (!(CheckInstalled bazel "0.15.0")) {

--- a/build.ps1
+++ b/build.ps1
@@ -100,7 +100,11 @@ $ENV:BAZEL_SH = "C:\msys64\usr\bin\bash.exe"
 if (!(CheckInstalled pacman)) {
     $version = askForVersion "20180531.0.0"
     choco install msys2 --version $version --params "/NoUpdate /InstallDir:C:\msys64"
-    pacman -S --noconfirm patch unzip tar
+    # Install tools that are necessary for buiding.
+    pacman -S --noconfirm patch unzip
+    if ($BuildCppProtoBuf) {
+        pacman -S --noconfirm tar
+    }
 }
 
 if (!(CheckInstalled bazel "0.15.0")) {


### PR DESCRIPTION
Installing ProtoBuf requires the tar util to be installed. Otherwise the messages is: The term 'tar' is not recognized as the name of a cmdlet
