### PR TITLE
Minor fix to allow script to compile 1.13.1 under VS2017

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -168,6 +168,9 @@ if ($buildVersion -eq "v1.11.0") {
     # Eigen Patch for v1.12.0
     git apply --ignore-space-change --ignore-white "..\patches\eigen.1.12.0.patch"
     Copy-Item ..\patches\eigen_half.patch third_party\
+} elseif ($buildVersion -eq "v1.13.1") {
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Invoke-WebRequest https://github.com/tensorflow/tensorflow/commit/ec727016282383aacf9d26386b01f6bdbd65b14b.patch | git apply -v --ignore-space-change --ignore-white
 }
 
 if ($BuildCppAPI) {
@@ -179,6 +182,9 @@ if ($BuildCppAPI) {
         # C++ Symbol Patch for v1.12.0
         git apply --ignore-space-change --ignore-white "..\patches\cpp_symbol.1.12.0.patch"
         Copy-Item ..\patches\tf_exported_symbols_msvc.lds tensorflow\
+    } elseif ($buildVersion -eq "v1.13.1") {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        Invoke-WebRequest https://github.com/tensorflow/tensorflow/commit/ec727016282383aacf9d26386b01f6bdbd65b14b.patch | git apply -v --ignore-space-change --ignore-white
     }
 }
 

--- a/build.ps1
+++ b/build.ps1
@@ -170,7 +170,7 @@ if ($buildVersion -eq "v1.11.0") {
     Copy-Item ..\patches\eigen_half.patch third_party\
 } elseif ($buildVersion -eq "v1.13.1") {
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    Invoke-WebRequest https://github.com/tensorflow/tensorflow/commit/ec727016282383aacf9d26386b01f6bdbd65b14b.patch | git apply -v --ignore-space-change --ignore-white
+    (Invoke-WebRequest https://github.com/tensorflow/tensorflow/commit/ec727016282383aacf9d26386b01f6bdbd65b14b.patch).Content | git apply -v --ignore-space-change --ignore-white
 }
 
 if ($BuildCppAPI) {
@@ -184,7 +184,7 @@ if ($BuildCppAPI) {
         Copy-Item ..\patches\tf_exported_symbols_msvc.lds tensorflow\
     } elseif ($buildVersion -eq "v1.13.1") {
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-        Invoke-WebRequest https://github.com/tensorflow/tensorflow/commit/ec727016282383aacf9d26386b01f6bdbd65b14b.patch | git apply -v --ignore-space-change --ignore-white
+        (Invoke-WebRequest https://github.com/tensorflow/tensorflow/commit/ec727016282383aacf9d26386b01f6bdbd65b14b.patch).Content | git apply -v --ignore-space-change --ignore-white
     }
 }
 

--- a/build.ps1
+++ b/build.ps1
@@ -182,9 +182,6 @@ if ($BuildCppAPI) {
         # C++ Symbol Patch for v1.12.0
         git apply --ignore-space-change --ignore-white "..\patches\cpp_symbol.1.12.0.patch"
         Copy-Item ..\patches\tf_exported_symbols_msvc.lds tensorflow\
-    } elseif ($buildVersion -eq "v1.13.1") {
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-        (Invoke-WebRequest https://github.com/tensorflow/tensorflow/commit/ec727016282383aacf9d26386b01f6bdbd65b14b.patch).Content | git apply -v --ignore-space-change --ignore-white
     }
 }
 


### PR DESCRIPTION
A small patch is needed in the source file op_kernel.h to allow the script to sucessfully compile  v1.13.1 under Visual Studio 2017, see https://github.com/tensorflow/tensorflow/pull/25943